### PR TITLE
new stable repo url (#61)

### DIFF
--- a/.ci/ct-config.yaml
+++ b/.ci/ct-config.yaml
@@ -2,4 +2,6 @@
 remote: origin
 chart-dirs:
   - charts
-helm-extra-args: --timeout 600
+chart-repos:
+  - stable=https://charts.helm.sh/stable
+helm-extra-args: --timeout 600s


### PR DESCRIPTION
helm has https://kubernetes-charts.storage.googleapis.com/index.yaml and
this no longer resolves. Adding the new repository
https://charts.helm.sh/stable

Signed-off-by: Rowan Ruseler <rowanruseler@gmail.com>

#### Which issue this PR fixes
Should allow automated testing to complete correctly (https://github.com/rowanruseler/helm-charts/pull/60#issuecomment-749899028).